### PR TITLE
Fix wiki repo link on home page

### DIFF
--- a/home.html
+++ b/home.html
@@ -21,7 +21,7 @@ dateCreated: 2023-05-16T06:28:34.570Z
     <p>
       This wiki is still a work in progress, so keep checking back for updates
       on new content! It is edited via a
-      <a href="https://github.com/TeamRizu/outfox-wiki" class="is-external-link"
+      <a href="https://github.com/TeamRizu/outfox-wikijs" class="is-external-link"
         >Git repository</a
       >; commit access is limited to the development team, but you can always
       perform pull requests too.


### PR DESCRIPTION
There's a `home.md`, but I've checked it wasn't the one (should be removed).

Also the old wiki repo should be archived to prevent confusion.

P.S. please check https://github.com/TeamRizu/outfox-wikijs/pull/1