### PR TITLE
Remove forum links

### DIFF
--- a/user-guide/meta/about.md
+++ b/user-guide/meta/about.md
@@ -42,7 +42,7 @@ The design members are the ones who work on assets, themes and frontend.
 
 The community members assists by creating, maintaining and expanding community projects and organizations, such as:
 
-- Moderating the [Discord Server](https://discord.gg/cN4TjgQdcA), [Forum](https://discourse.projectmoon.dance/), [Subreddit](https://www.reddit.com/r/OutFox/) and our [Bug Hunter Repository](https://github.com/TeamRizu/OutFox);
+- Moderating the [Discord Server](https://discord.gg/cN4TjgQdcA), [Subreddit](https://www.reddit.com/r/OutFox/) and our [Bug Hunter Repository](https://github.com/TeamRizu/OutFox);
 - Coordinating [Tiny-Foxes](https://github.com/Tiny-Foxes), a community group focusing on add-ons and localizations for Project OutFox.
 
 The Serenity Team is a subset of Community team, created to help work on the creation and organization of [OutFox Community Pack](https://projectoutfox.com/outfox-serenity).

--- a/user-guide/meta/faq.md
+++ b/user-guide/meta/faq.md
@@ -34,8 +34,6 @@ You can also use this [Discord Server](https://discord.gg/cN4TjgQdcA):
 Use "feature-request" channel to request features or give ideas.
 Use "bugs-crashlogs" channel to report bugs and game crashes.
 
-You can also use [our forum](https://discourse.projectmoon.dance/)
-
 ## Are there ways I can contribute?
 
 - You can report bugs and make feature suggestions on our Discord server.

--- a/user-guide/meta/serenity.md
+++ b/user-guide/meta/serenity.md
@@ -101,7 +101,6 @@ Another possible reason is that your submission does not follow the **music guid
 
 - [Discord](https://discord.gg/mNcFU67mK7)
 - [Reddit](https://www.reddit.com/r/OutFox) (Post or Private Message any Mods)
-- [Project OutFox Forum](https://discourse.projectmoon.dance/) (Create a post)
 - [Twitter](https://twitter.com/projectoutfox) (Private Message)
 - [Facebook](https://www.facebook.com/ProjectOutFox/) (Private Message)
 - [Github](https://github.com/TeamRizu/OutFox/discussions) (New Discussion)

--- a/user-guide/setup/getting-started.md
+++ b/user-guide/setup/getting-started.md
@@ -155,6 +155,6 @@ From the profile editor (highlight a profile and press Start, and then select "E
 
 # Next steps
 
-The only thing left to do is have fun! If you need more help with Project OutFox, check out the other pages in our wiki documentation, and join other members of our community on our [Discord server](https://discord.gg/cN4TjgQdcA) or [forum](https://discourse.projectmoon.dance/).
+The only thing left to do is have fun! If you need more help with Project OutFox, check out the other pages in our wiki documentation, and join other members of our community on our [Discord server](https://discord.gg/cN4TjgQdcA).
 
 Thank you for supporting Project OutFox!


### PR DESCRIPTION
According to wayback machine, the forums went out of commission late 2023 and the main site removed the link from the support dropdown around last month.