### PR TITLE
Document `SDL2` input driver

### DIFF
--- a/user-guide/config/preferences.md
+++ b/user-guide/config/preferences.md
@@ -909,11 +909,11 @@ The input drivers the game will use. If nothing is specified, the following defa
 
 Windows: ``Para,legacy,minisdl``
 
-Mac: ``portmidi,SDL``
+Mac: ``portmidi,SDL`` (lts4), ``SDL2`` (alpha5)
 
-Linux: ``SDL``
+Linux: ``SDL`` (lts4), ``SDL2`` (alpha5)
 
-The possible values are ``Rtio`` (Windows-only), ``legacy`` (Windows-only), ``SDL``, ``Reflex``, ``rtmidi``, ``Python23IO``, ``portmidi``, ``para``, ``minisdl`` and ``ps3ddr`` (alpha5-only)
+The possible values are ``Rtio`` (Windows-only), ``legacy`` (Windows-only), ``SDL``, ``SDL2`` (alpha5-only), ``Reflex``, ``rtmidi``, ``Python23IO``, ``portmidi``, ``para``, ``minisdl`` and ``ps3ddr`` (alpha5-only)
 
 Default value: nothing
 


### PR DESCRIPTION
Ref: https://discord.com/channels/422897054386225173/428678897815781378/1353599163371098132

Have checked defaults on alpha5 with the "show stats" setting on. Windows seems to have the same defaults on both outfox versions.

Couldn't confirm the defaults of lts4 since the stats on the top right don't show input drivers until alpha5, so I'd assume what was listed before as lts4.

And can confirm `SDL2` is alpha5-only because it doesn't get detected / crashes in lts4.