### PR TITLE
Fix many typos

### DIFF
--- a/dev/actors/ActorsLua-CommandList.md
+++ b/dev/actors/ActorsLua-CommandList.md
@@ -967,7 +967,7 @@ Called when the music wheel is starting the roulette
 ---
 ### `StartRandomMessageCommand`
 
-Called when the music wheel choosing a random song from the Random item.
+Called when the music wheel is choosing a random song from the Random item.
 
 ---
 ### `CoinInsertedMessageCommand`

--- a/dev/actors/ActorsLua-CommandList.md
+++ b/dev/actors/ActorsLua-CommandList.md
@@ -967,12 +967,12 @@ Called when the music wheel is starting the roulette
 ---
 ### `StartRandomMessageCommand`
 
-Called when the music wheel chosing a random song from the Random item.
+Called when the music wheel choosing a random song from the Random item.
 
 ---
 ### `CoinInsertedMessageCommand`
 
-Called when insering a coin and clearing credits.
+Called when inserting a coin and clearing credits.
 
 Themes can use this command to update other actors about coin information (Does not send any data).
 
@@ -1273,7 +1273,7 @@ Parameters:
 ---
 ### `StepP1MessageCommand / StepP2MessageCommand`
 
-Called when any player steps. For backwards compatbility with older content.
+Called when any player steps. For backwards compatibility with older content.
 
 ---
 ### `JudgmentMessageCommand`
@@ -1321,7 +1321,7 @@ Parameters:
 ---
 ### `<DeviceInput>PressedMessageCommand / <DeviceInput>ReleasedMessageCommand`
 
-Called from ScreenTestInput when recieving input. \<DeviceInput> is replaced with a ToString'd input name.
+Called from ScreenTestInput when receiving input. \<DeviceInput> is replaced with a ToString'd input name.
 
 ---
 ### `UpdateScreenheaderMessageCommand`

--- a/dev/actors/General-DifferencesfromOlderSM.md
+++ b/dev/actors/General-DifferencesfromOlderSM.md
@@ -60,7 +60,7 @@ SM5 applies the zoom and then applies the rotation.
 
 In Project OutFox, this can be worked around by setting the `rotafterzoom` attribute to false, returning the SM3.95 behavior.
 
-The notes & receptors already have this active to help with easilly replicating modifier effects from the other engines.
+The notes & receptors already have this active to help with easily replicating modifier effects from the other engines.
 
 In SM5.2 and earlier, this has to be done with wrapper states or actorframes. This is done by having the wrapper do the positioning and zooming, while the main actor gets everything else. (This is still doable in Project OutFox if you're aiming to write content for multiple SM5s)
 

--- a/dev/actors/actortypes.md
+++ b/dev/actors/actortypes.md
@@ -263,7 +263,7 @@ A screen the theme can go to. There are screens for gameplay, selecting music, p
 
 Displays the data for a given chart. Can show difficulty number, description, credit, if it's autogen and steps type.
 
-Currently, all setings are done through metrics.
+Currently, all settings are done through metrics.
 
 ## StepsDisplayList
 

--- a/dev/actors/actortypes/actor.md
+++ b/dev/actors/actortypes/actor.md
@@ -28,7 +28,7 @@ Def.Actor{
 | Name | Type | Description |
 | :--- | :--- | ----------- |
 [Name]Command | function | The basis for any command. Check [Commands](#commands) for more information.
-Name | string | The name for the actor. Giving this a value allows this actor to be obtain by its name by any other actor. Check [Obtaining Childs and ActorFrame Levels](#obtaining-childs-and-actorframe-levels) for more information.
+Name | string | The name for the actor. Giving this a value allows this actor to be obtain by its name by any other actor. Check [Obtaining Children and ActorFrame Levels](#obtaining-children-and-actorframe-levels) for more information.
 BaseRotationX | number | The base rotation for the X axis. Any rotation value is added ON TOP of this value.
 BaseRotationY | number | The base rotation for the Y axis. Any rotation value is added ON TOP of this value.
 BaseRotationZ | number | The base rotation for the Z axis. Any rotation value is added ON TOP of this value.
@@ -102,7 +102,7 @@ end
 
 If one wants to pass custom parameters into the command, a single table has to be used to wrap every parameter passed.
 
-These command functions generally take two paramters: The actor calling the function (often called `self`), and the parameters table passed into the command. The paramters table is optional.
+These command functions generally take two parameters: The actor calling the function (often called `self`), and the parameters table passed into the command. The parameters table is optional.
 
 ```lua
 self:playcommand("Action", { --[[Values are added here like a regular table.]] })
@@ -118,7 +118,7 @@ end
 <!-- TODO: Document the difference between the two and add more notes!-->
 
 
-# Obtaining Childs and ActorFrame Levels
+# Obtaining Children and ActorFrame Levels
 
 When using [Actors](/en/dev/actors/actortypes/actor), you can use `self:GetParent()` and `self:GetChild()` to get elements from other [ActorFrames](/en/dev/actors/actortypes/actorframe) or [Actors](/en/dev/actors/actortypes/actor).
 

--- a/dev/actors/actortypes/actor.md
+++ b/dev/actors/actortypes/actor.md
@@ -28,7 +28,7 @@ Def.Actor{
 | Name | Type | Description |
 | :--- | :--- | ----------- |
 [Name]Command | function | The basis for any command. Check [Commands](#commands) for more information.
-Name | string | The name for the actor. Giving this a value allows this actor to be obtain by its name by any other actor. Check [Obtaining Children and ActorFrame Levels](#obtaining-children-and-actorframe-levels) for more information.
+Name | string | The name for the actor. Giving this a value allows this actor to be obtain by its name by any other actor. Check [Obtaining Child and ActorFrame Levels](#obtaining-child-and-actorframe-levels) for more information.
 BaseRotationX | number | The base rotation for the X axis. Any rotation value is added ON TOP of this value.
 BaseRotationY | number | The base rotation for the Y axis. Any rotation value is added ON TOP of this value.
 BaseRotationZ | number | The base rotation for the Z axis. Any rotation value is added ON TOP of this value.
@@ -118,7 +118,7 @@ end
 <!-- TODO: Document the difference between the two and add more notes!-->
 
 
-# Obtaining Children and ActorFrame Levels
+# Obtaining Child and ActorFrame Levels
 
 When using [Actors](/en/dev/actors/actortypes/actor), you can use `self:GetParent()` and `self:GetChild()` to get elements from other [ActorFrames](/en/dev/actors/actortypes/actorframe) or [Actors](/en/dev/actors/actortypes/actor).
 

--- a/dev/actors/actortypes/actor/ActorsLua-Anatomy+Structure.md
+++ b/dev/actors/actortypes/actor/ActorsLua-Anatomy+Structure.md
@@ -72,7 +72,7 @@ end
 
 If one wants to pass custom parameters into the command, a single table has to be used to wrap every parameter passed.
 
-These command functions generally take two paramters: The actor calling the function (often called `self`), and the parameters table passed into the command. The paramters table is optional.
+These command functions generally take two parameters: The actor calling the function (often called `self`), and the parameters table passed into the command. The parameters table is optional.
 
 ```lua
 self:playcommand("Action", { --[[Values are added here like a regular table.]] })

--- a/dev/actors/actortypes/actor/obtainlevels.md
+++ b/dev/actors/actortypes/actor/obtainlevels.md
@@ -1,5 +1,5 @@
 ---
-title: Obtaining Children and ActorFrame Levels
+title: Obtaining Child and ActorFrame Levels
 description: 
 published: true
 date: 2023-11-04T05:19:23.594Z

--- a/dev/actors/actortypes/actor/obtainlevels.md
+++ b/dev/actors/actortypes/actor/obtainlevels.md
@@ -1,5 +1,5 @@
 ---
-title: Obtaining Childs and ActorFrame Levels
+title: Obtaining Children and ActorFrame Levels
 description: 
 published: true
 date: 2023-11-04T05:19:23.594Z

--- a/dev/actors/actortypes/actorframe.md
+++ b/dev/actors/actortypes/actorframe.md
@@ -59,7 +59,7 @@ Def.ActorFrame{
 
 Because lua tables can be concatenated (added) to each other, so can ActorFrames.
 
-This can allow for programatically creating [Actor](/en/dev/actors/actortypes/actor) in batches as needed.
+This can allow for programmatically creating [Actor](/en/dev/actors/actortypes/actor) in batches as needed.
 
 However, if one does not plan on creating [Actor](/en/dev/actors/actortypes/actor) programmaticly, then a simple `return Def.ActorFrame{...` is all that's needed. Storing it into a local variable that gets returned will waste resources.
 
@@ -142,4 +142,4 @@ If there are multiple children with that name, returns an array of those childre
 The table also acts as a pass through layer, function calls pass through to the last child of that name.
 
 obtainlevels
-For more information about how obtaining ActorFrame childs work, check [Obtaining Childs and ActorFrame Levels](/en/dev/actors/actortypes/actor#obtaining-childs-and-actorframe-levels).
+For more information about how obtaining ActorFrame children work, check [Obtaining Children and ActorFrame Levels](/en/dev/actors/actortypes/actor#obtaining-childs-and-actorframe-levels).

--- a/dev/actors/actortypes/actorframe.md
+++ b/dev/actors/actortypes/actorframe.md
@@ -142,4 +142,4 @@ If there are multiple children with that name, returns an array of those childre
 The table also acts as a pass through layer, function calls pass through to the last child of that name.
 
 obtainlevels
-For more information about how obtaining ActorFrame children work, check [Obtaining Children and ActorFrame Levels](/en/dev/actors/actortypes/actor#obtaining-childs-and-actorframe-levels).
+For more information about how obtaining ActorFrame children work, check [Obtaining Children and ActorFrame Levels](/en/dev/actors/actortypes/actor#obtaining-children-and-actorframe-levels).

--- a/dev/actors/actortypes/actorframe.md
+++ b/dev/actors/actortypes/actorframe.md
@@ -142,4 +142,4 @@ If there are multiple children with that name, returns an array of those childre
 The table also acts as a pass through layer, function calls pass through to the last child of that name.
 
 obtainlevels
-For more information about how obtaining ActorFrame children work, check [Obtaining Children and ActorFrame Levels](/en/dev/actors/actortypes/actor#obtaining-children-and-actorframe-levels).
+For more information about how obtaining ActorFrame children work, check [Obtaining Child and ActorFrame Levels](/en/dev/actors/actortypes/actor#obtaining-child-and-actorframe-levels).

--- a/dev/actors/actortypes/actormultivertex.md
+++ b/dev/actors/actortypes/actormultivertex.md
@@ -121,7 +121,7 @@ For written examples, please check [Usage Examples](#usage-examples).
 | Fan | Constructs an 8 polygonal shape that can be used to resemble a fan. | ![drawmode_fan.svg](/resources/actors/actormultivertex/drawmode_fan.svg) |
 | Strip | Suspiciously similar to DrawMode_QuadStrip. | ![drawmode_quadstrip.svg](/resources/actors/actormultivertex/drawmode_quadstrip.svg) |
 | Triangles | Draws a 3 point polygonal shape that is separated from any adjacent or subsequent point. | ![drawmode_triangle.svg](/resources/actors/actormultivertex/drawmode_triangle.svg) |
-| LineStrip | Draws a continous line based on the points given to the Polygon. Width of the line is scaled by the theme's internal height, plus the manual value assigned. | ![drawmode_linestrip.svg](/resources/actors/actormultivertex/drawmode_linestrip.svg) |
+| LineStrip | Draws a continuous line based on the points given to the Polygon. Width of the line is scaled by the theme's internal height, plus the manual value assigned. | ![drawmode_linestrip.svg](/resources/actors/actormultivertex/drawmode_linestrip.svg) |
 | SymmetricQuadStrip | todo | todo |
 
 The following are introduced for OutFox.

--- a/dev/actors/actortypes/actorproxy.md
+++ b/dev/actors/actortypes/actorproxy.md
@@ -80,7 +80,7 @@ t[#t+1] = Def.ActorProxy{
 return t
 ```
 
-> Alternatively, the handle can also be provided by calling GetChild to that same actor from the Proxy itself, by utilizing the tricks from [Obtaining Children and ActorFrame levels](/en/dev/actors/actortypes/actor#obtaining-childs-and-actorframe-levels).
+> Alternatively, the handle can also be provided by calling GetChild to that same actor from the Proxy itself, by utilizing the tricks from [Obtaining Children and ActorFrame levels](/en/dev/actors/actortypes/actor#obtaining-children-and-actorframe-levels).
 {.is-info}
 
 ```lua

--- a/dev/actors/actortypes/actorproxy.md
+++ b/dev/actors/actortypes/actorproxy.md
@@ -80,7 +80,7 @@ t[#t+1] = Def.ActorProxy{
 return t
 ```
 
-> Alternatively, the handle can also be provided by calling GetChild to that same actor from the Proxy itself, by utilizing the tricks from [Obtaining Children and ActorFrame levels](/en/dev/actors/actortypes/actor#obtaining-children-and-actorframe-levels).
+> Alternatively, the handle can also be provided by calling GetChild to that same actor from the Proxy itself, by utilizing the tricks from [Obtaining Child and ActorFrame Levels](/en/dev/actors/actortypes/actor#obtaining-child-and-actorframe-levels).
 {.is-info}
 
 ```lua

--- a/dev/actors/actortypes/actorproxy.md
+++ b/dev/actors/actortypes/actorproxy.md
@@ -80,7 +80,7 @@ t[#t+1] = Def.ActorProxy{
 return t
 ```
 
-> Alternatively, the handle can also be provided by calling GetChild to that same actor from the Proxy itself, by utilizing the tricks from [Obtaining Childs and ActorFrame levels](/en/dev/actors/actortypes/actor#obtaining-childs-and-actorframe-levels).
+> Alternatively, the handle can also be provided by calling GetChild to that same actor from the Proxy itself, by utilizing the tricks from [Obtaining Children and ActorFrame levels](/en/dev/actors/actortypes/actor#obtaining-childs-and-actorframe-levels).
 {.is-info}
 
 ```lua

--- a/dev/actors/actortypes/actorscroller.md
+++ b/dev/actors/actortypes/actorscroller.md
@@ -125,7 +125,7 @@ TransformFunction=function(self, offset, itemIndex, numItems)
 end
 ```
 
-Here we're telling the game to perform the operation on the X and Y axis, and they're using cosine and sine respectively. [These two values return a value of -1 to 1](https://en.wikipedia.org/wiki/Sine_and_cosine#/media/File:Sine_cosine_one_period.svg). By having these two values in sync with each other, we're effectively creating a circunference, which in turns provides us with a circle.
+Here we're telling the game to perform the operation on the X and Y axis, and they're using cosine and sine respectively. [These two values return a value of -1 to 1](https://en.wikipedia.org/wiki/Sine_and_cosine#/media/File:Sine_cosine_one_period.svg). By having these two values in sync with each other, we're effectively creating a circumference, which in turns provides us with a circle.
 
 ### Subdivisions
 

--- a/dev/actors/actortypes/bitmaptext/Bitmap-InlineColoring.md
+++ b/dev/actors/actortypes/bitmaptext/Bitmap-InlineColoring.md
@@ -60,7 +60,7 @@ local function ConvertText( child )
 		}
 	end
 	
-	-- We're done. Apply the resulting table's atributes to the text.
+	-- We're done. Apply the resulting table's attributes to the text.
 	for k,v in pairs( ColoringProcess ) do
 		child:AddAttribute( v.Start, v.Attr )
 	end

--- a/dev/actors/actortypes/dynamicactorscroller.md
+++ b/dev/actors/actortypes/dynamicactorscroller.md
@@ -37,7 +37,7 @@ The attributes for DynamicActorScroller are the same as [ActorScroller](/en/dev/
 
 | Name | Type | Action |
 | :--- | :--- | :----- |
-LoadFunction |  function |  **New to DynamicActorScroller**, determines the ammount of items to be generated. provides two arguments which are nil at the start.
+LoadFunction |  function |  **New to DynamicActorScroller**, determines the amount of items to be generated. provides two arguments which are nil at the start.
 
 The following are the regular attributes.
 | Name | Type | Action |

--- a/dev/actors/actortypes/gradedisplay.md
+++ b/dev/actors/actortypes/gradedisplay.md
@@ -31,7 +31,7 @@ Load the graphics from a defined "metrics" group. It will seek for grade images 
 [sMetricsGroup] Grade
 ```
 
-> Internally it is called metrics, but this actor doesn't use any kind of graphics directly, other than the ammount of grades defined by `PlayerStageStats::NumGradeTiersUsed`.
+> Internally it is called metrics, but this actor doesn't use any kind of graphics directly, other than the amount of grades defined by `PlayerStageStats::NumGradeTiersUsed`.
 {.is-info}
 
 ### `SetGrade`

--- a/dev/actors/actortypes/grooveradar.md
+++ b/dev/actors/actortypes/grooveradar.md
@@ -57,7 +57,7 @@ RadarValueMapP2OnCommand=diffuse,PlayerColor(PLAYER_2)
 ### `SetFromRadarValues`
 `(PlayerNumber player, RadarValues data)`
 
-Sets the data for the GrooveRadar from a chart's RadarValues. These values are generated data when saving the chart which precalculate information like jump intensity, chaos charting, ammount of holds, etc.
+Sets the data for the GrooveRadar from a chart's RadarValues. These values are generated data when saving the chart which precalculate information like jump intensity, chaos charting, amount of holds, etc.
 
 If RadarValues is nil, it will perform the same action as [`SetEmpty`](#setempty).
 

--- a/dev/actors/actortypes/lifemeter.md
+++ b/dev/actors/actortypes/lifemeter.md
@@ -28,7 +28,7 @@ Returns a value from 0 to 1.
 
 ### Battery
 
-Returns a converted value from the current lifes left and the starting ammount of batteries.
+Returns a converted value from the current lives left and the starting amount of batteries.
 
 ```
 Lives Left / Batteries Max
@@ -36,7 +36,7 @@ Lives Left / Batteries Max
 
 ### Time
 
-Retuns a converted value from the current time remaining against a hard-coded value of 90. This value is clamped to return a value from 0 to 1.
+Returns a converted value from the current time remaining against a hard-coded value of 90. This value is clamped to return a value from 0 to 1.
 
 ```
 Time Left / 90.

--- a/dev/actors/actortypes/notefield/DefNoteField-RunningModifiers.md
+++ b/dev/actors/actortypes/notefield/DefNoteField-RunningModifiers.md
@@ -19,7 +19,7 @@ Applying modifiers is instant, unlike the approach rate behavior usually seen.
 This can be done through multiple ways:
 
 ### 1. Using the ModsFromString function in the NoteField.
-- Allows one to easilly set the modifiers on the [NoteField](/en/dev/actors/actortypes/notefield/_index) through modstrings.
+- Allows one to easily set the modifiers on the [NoteField](/en/dev/actors/actortypes/notefield/_index) through modstrings.
 - Some modifiers will not be usable through modstrings.
 
 ```lua

--- a/dev/actors/actortypes/notefield/NoteField-InputManipulation.md
+++ b/dev/actors/actortypes/notefield/NoteField-InputManipulation.md
@@ -36,7 +36,7 @@ The function takes a column (First column is 1), and a TapNoteScore enum.
 
 ## Callbacks
 
-A [NoteField](/en/dev/actors/actortypes/notefield/_index) can have functions attatched to various actions.
+A [NoteField](/en/dev/actors/actortypes/notefield/_index) can have functions attached to various actions.
 
 The given callback function are allowed to return its' own values, which the [NoteField](/en/dev/actors/actortypes/notefield/_index) will respect instead.
 

--- a/dev/actors/actortypes/rollingnumbers.md
+++ b/dev/actors/actortypes/rollingnumbers.md
@@ -59,7 +59,7 @@ self:Load("MyNumbers")
 
 # Actor Behaviour
 
-Based on the value of `ApproachSeconds`, the actor will attempt to approach the **target value** in the same ammount of time. Attempting to use `targetnumber` without loading a metrics group previously will lead to warning requesting a group.
+Based on the value of `ApproachSeconds`, the actor will attempt to approach the **target value** in the same amount of time. Attempting to use `targetnumber` without loading a metrics group previously will lead to warning requesting a group.
 
 > You must use `Load` to load the metrics for a RollingNumbers actor before doing anything else.
 {.is-warning}

--- a/dev/actors/actortypes/sound.md
+++ b/dev/actors/actortypes/sound.md
@@ -29,7 +29,7 @@ Def.Sound{
 		self:play()
 
 		-- If the audio has the "(loop)" flag set on its filename, it will loop infinetly. So to top it, use the
-		-- appropiate command.
+		-- appropriate command.
 		self:stop()
 
 		-- If the sound needs to be paused on a particular frame, and not to reset, use the pause command.
@@ -60,7 +60,7 @@ local MyRageSound = self:get()
 ```
 
 With this object obtained, you can control elements like the sound's position, volume, pitch and speed.
-Note that some components need some flags to be enabled which have been pointed out as commments alongside them.
+Note that some components need some flags to be enabled which have been pointed out as comments alongside them.
 ```lua
 -- This function will return the value for the Def.Sound's RageSound component, which allows for expanded
 -- controls.

--- a/dev/actors/actortypes/sound/Sound-ControllingSound.md
+++ b/dev/actors/actortypes/sound/Sound-ControllingSound.md
@@ -18,7 +18,7 @@ local MyRageSound = self:get()
 ```
 
 With this object obtained, you can control elements like the sound's position, volume, pitch and speed.
-Note that some components need some flags to be enabled which have been pointed out as commments alongside them.
+Note that some components need some flags to be enabled which have been pointed out as comments alongside them.
 ```lua
 -- This function will return the value for the Def.Sound's RageSound component, which allows for expanded
 -- controls.

--- a/dev/actors/actortypes/sprite.md
+++ b/dev/actors/actortypes/sprite.md
@@ -76,7 +76,7 @@ The frames in a sprite are composed of an array containing arrays of two values,
 > ```
 > {.is-warning}
 
-As an example to demonstate each sprite table, we'll utilize the fox from the staff roll.
+As an example to demonstrate each sprite table, we'll utilize the fox from the staff roll.
 
 ## Standard format
 

--- a/dev/actors/actortypes/sprite/Frames.md
+++ b/dev/actors/actortypes/sprite/Frames.md
@@ -17,7 +17,7 @@ The frames in a sprite are composed of an array containing arrays of two values,
 > ```
 > {.is-warning}
 
-As an example to demonstate each sprite table, we'll utilize the fox from the staff roll.
+As an example to demonstrate each sprite table, we'll utilize the fox from the staff roll.
 
 ## Standard format
 

--- a/dev/actors/actortypes/stepsdisplay.md
+++ b/dev/actors/actortypes/stepsdisplay.md
@@ -8,7 +8,7 @@ editor: markdown
 dateCreated: 2023-05-16T06:16:18.627Z
 ---
 
-Displays the data for a given chart. Can show difficulty number, description, credit, if it’s autogen and steps type. Currently, all setings are done through metrics.
+Displays the data for a given chart. Can show difficulty number, description, credit, if it’s autogen and steps type. Currently, all settings are done through metrics.
 
 ```lua
 Def.StepsDisplay{}
@@ -16,7 +16,7 @@ Def.StepsDisplay{}
 
 ## Attributes
 
-There are no special atributes for this actor class. It inherits the atributes from [ActorFrame](/en/dev/actors/actortypes/actorframe). All special actions are performed with its [functions](#functions).
+There are no special attributes for this actor class. It inherits the attributes from [ActorFrame](/en/dev/actors/actortypes/actorframe). All special actions are performed with its [functions](#functions).
 
 ## Metrics Loading
 
@@ -25,7 +25,7 @@ When using the `Load` command, the following metrics are read to generate the St
 | Name | Type | Action |
 | :--- | :--- | :----- |
 NumTicks | number | Amount of ticks to show all the time.
-MaxTicks | number | The max ammount of ticks to draw.
+MaxTicks | number | The max amount of ticks to draw.
 ShowTicks | bool | Enables the ticks. These are graphics that indicate the number of difficulty in individual blocks.
 ShowMeter | bool | Enables the meter number.
 ShowDescription | bool | Enables the chart description (if available).

--- a/dev/actors/actortypes/textbanner.md
+++ b/dev/actors/actortypes/textbanner.md
@@ -30,9 +30,9 @@ Def.TextBanner {
 }
 ```
 
-## Atributes
+## Attributes
 
-There are no special atributes for this actor class. It inherits the atributes from [ActorFrame](/en/dev/actors/actortypes/actorframe).
+There are no special attributes for this actor class. It inherits the attributes from [ActorFrame](/en/dev/actors/actortypes/actorframe).
 
 ## Data used on load
 
@@ -67,7 +67,7 @@ If there is a PrependString of "/"..
 `AfterSetCommand` is a function that is called after all data has been processed on the TextBanner.
 This can be useful to fix any visual errors that might happen like overflowing text, incorrect sizing, and others.
 
-> You may notice on the mayority of themes, this metric contains a value like this:
+> You may notice on the majority of themes, this metric contains a value like this:
 > ```ini
 > AfterSetCommand=%TextBannerAfterSet
 > ```

--- a/dev/announcers.md
+++ b/dev/announcers.md
@@ -24,7 +24,7 @@ Project OutFox/Announcers/
 		└───OutFox.ogg
 ```
 
-# Funcionality
+# Functionality
 
 Depending on the screen the player is currently on, certain announcer sounds will play. Here we will list the items used in the engine, and talk about custom sounds.
 
@@ -244,7 +244,7 @@ Because of the Tier system in modern SM, the tier is converted into a human read
   
 <details>
   
-  <summary>Click here for the list of old grades correspondant to the tier.</summary>
+  <summary>Click here for the list of old grades correspondent to the tier.</summary>
  
 | Tier | Old Grade conversion |
 | :--: | :------------------: |

--- a/dev/courses.md
+++ b/dev/courses.md
@@ -23,7 +23,7 @@ Project OutFox/Courses/
 └───Singular course.crs
 ```
 
-A colection (folder) can have as many courses inside of it as it wishes. The name of the folder is not used
+A collection (folder) can have as many courses inside of it as it wishes. The name of the folder is not used
 on selection however, as described on the `instruction.txt` file.
 >Course files (.crs) typically go in folders, though they aren't shown like that on the wheel... yet. (Coming soon: a metric that allows a theme to do that, once we get the wheel to treat course directories like song directories)
 
@@ -109,7 +109,7 @@ Instead of a particular song, a random one can be chosen by using the wildcard o
 ```
 
 ```
-#SONG:*; # Will pick a random song from the entire instalation.	
+#SONG:*; # Will pick a random song from the entire installation.	
 ```
 
 ### #COURSETRANSLIT

--- a/dev/custom-shaders/Intro.md
+++ b/dev/custom-shaders/Intro.md
@@ -42,7 +42,7 @@ To enable custom shaders, set the preference `CustomShadersDisabled` to 0.
 If disabled, attempting to do anything involving custom shaders will just give a warning in the game logs.
 
 ## Checking for ability to use Custom Shaders
-If you are a gimmick or theme creator, you can easilly check in lua with GetPreference:
+If you are a gimmick or theme creator, you can easily check in lua with GetPreference:
 ```lua
 local noShader = PREFSMAN:GetPreference('CustomShadersDisabled') -- true = custom shaders are disabled
 ```

--- a/dev/effects/EffectFiles-ChartSegments.md
+++ b/dev/effects/EffectFiles-ChartSegments.md
@@ -109,7 +109,7 @@ In simfile, it's listed as the beat it happens, the speed to go to, how long the
 
 ### Scroll segments (SCROLLS)
 
-Allows one to alter the scrolling factor for a section (as opposed to the whole field). When given a factor of 0, the chart stops visibly scrollnig, but notes can still be hit. Visually ignored if CMod is used.
+Allows one to alter the scrolling factor for a section (as opposed to the whole field). When given a factor of 0, the chart stops visibly scrolling, but notes can still be hit. Visually ignored if CMod is used.
 
 In simfile, it's listed as the beat it happens, and then the factor to switch to.
 ```

--- a/dev/effects/EffectFiles-ModifierFiles.md
+++ b/dev/effects/EffectFiles-ModifierFiles.md
@@ -23,7 +23,7 @@ There are a few ways to go about this, and it varys depending on what version of
 
 ### ApplyGameCommand (SM3.95/oITG/nITG)
 
-ApplyGameCommand is a GameState function that provides a way to send modifiers among other commands. The first paramter is the command type followed by the parameters. (In this case, a modstring) The second parameter is what player to apply the command (1 = player 1). If not specified, it applies to all players.
+ApplyGameCommand is a GameState function that provides a way to send modifiers among other commands. The first parameter is the command type followed by the parameters. (In this case, a modstring) The second parameter is what player to apply the command (1 = player 1). If not specified, it applies to all players.
 
 ```lua
 GAMESTATE:ApplyGameCommand("mod, *0.5 420 beat", 1)
@@ -41,7 +41,7 @@ Old modfiles used to require going into marathon mode to play the scripted modif
 ```
 (ex: Beat starts at 0 seconds and ends at 10. Stealth turns on at 5 seconds and ends 1.6 seconds later)
 
-Nowadays, this is considered obsolete in favor of lua-powered modifiers. It's still usuable in SM5.
+Nowadays, this is considered obsolete in favor of lua-powered modifiers. It's still usable in SM5.
 
 ### #ATTACKS (Simfiles, nITG/SM5)
 
@@ -118,7 +118,7 @@ return Def.ActorFrame {
 
 ## Modfile templates
 
-Starting to make a modfile can seem really daunting if one does not know how to begin. Luckilly, there are many templates out there to help with creating modfiles.
+Starting to make a modfile can seem really daunting if one does not know how to begin. Luckily, there are many templates out there to help with creating modfiles.
 
 Ones made for SM3.95 and Open/NotITG are usually done with .xml files, and some rare .lua files.
 
@@ -221,7 +221,7 @@ TODO: I'm gonna need everyone else's help from the mods community when we start 
 
 - XeroOl's Galaxy Mod Loader (XGML) template
 	- https://github.com/XeroOl/notitg-xgml
-	- Predecesor to mirin
+	- Predecessor to mirin
 	- Considered deprecated/obsolete?
 	- Has addons to extend template functionality
 		- https://github.com/XeroOl/notitg-xgml-addons

--- a/dev/effects/_index.md
+++ b/dev/effects/_index.md
@@ -12,7 +12,7 @@ Normal gameplay is as follows: Notes move up or down towards the target on a usu
 
 Effect simfiles change this up, which can result in interesting gameplay results.
 
-There are multiple 'catagories' of effect files:
+There are multiple 'categories' of effect files:
 - "Gimmick" charts
     - While not really an 'effect', per-say, gimmick charts can change up how one reads a chart.
     - A single BPM or stop doesn't really count as a 'gimmick'.

--- a/dev/mode-support/bms-pms-support.md
+++ b/dev/mode-support/bms-pms-support.md
@@ -183,7 +183,7 @@ Usage Example:
 ```
 #TOTAL 430
 ```
-The `TOTAL` command is to set the value of what could be considered an extension of the 'gauge' in older simulators, before _life gauges_ existed. The value of `TOTAL` is added to a normal gauge to increase it's length. if the value was 300, then the gauge would go from 0 to 100% in size, to the intial value (normally around 25% + 300% for a total gauge size of 325%). 
+The `TOTAL` command is to set the value of what could be considered an extension of the 'gauge' in older simulators, before _life gauges_ existed. The value of `TOTAL` is added to a normal gauge to increase it's length. if the value was 300, then the gauge would go from 0 to 100% in size, to the initial value (normally around 25% + 300% for a total gauge size of 325%). 
 
 This only occurs when the notes are hit and combo is kept, otherwise things would return to the old gauge size. It was more of a consideration on gauge/groove/clear amounts (what you needed to reach to be considered a pass in that song). This did lead to some confusion on how `TOTAL` should affect the gameplay/level of the chart.
 

--- a/dev/mode-support/ksf-support.md
+++ b/dev/mode-support/ksf-support.md
@@ -109,7 +109,7 @@ Example:
 ```
 ---
 ## ``DIFFICULTY``
-Sets the rating of the chart. Otherwise, values from the Difficulty secion above are used.
+Sets the rating of the chart. Otherwise, values from the Difficulty section above are used.
 
 Example:
 
@@ -253,9 +253,9 @@ Example: `|E12|` Makes a 12 beat delay segment.
 ---
 <!-- I'm unsure about this -->
 #### ``|Dn|``
-Sets a delay segment at the given beat for n miliseconds
+Sets a delay segment at the given beat for n milliseconds
 
-Example: `|D1000|` Makes a 1000 milisecond (1 second) delay segment.
+Example: `|D1000|` Makes a 1000 millisecond (1 second) delay segment.
 
 ---
 #### ``|Mn|`` / ``|Cn|``

--- a/dev/mode-support/sm-support.md
+++ b/dev/mode-support/sm-support.md
@@ -84,7 +84,7 @@ Example:
 ``` 
 ---
 ## ``GENRE``
-This is the genre of the song. Some examples are `Rock`, `Dubstep`, and `Classical`. Anythng can be put here as a genre.
+This is the genre of the song. Some examples are `Rock`, `Dubstep`, and `Classical`. Anything can be put here as a genre.
 
 Example:
 
@@ -143,7 +143,7 @@ Example:
 ``` 
 ---
 ## ``MUSIC``
-This defines the file to use for the song's music. This is usualy in the same folder as the simfile. This is a relative path.
+This defines the file to use for the song's music. This is usually in the same folder as the simfile. This is a relative path.
 
 Example:
 
@@ -152,7 +152,7 @@ Example:
 ``` 
 ---
 ## ``INSTRUMENTTRACK``
-Specifies a song file to use for an instrument track. This is a relative path. Valid intrument tracks are: "Guitar", "Rhythm", "Bass", "Vocal", "Drum1", "Drum2", "Drum3" and "Drum4"
+Specifies a song file to use for an instrument track. This is a relative path. Valid instrument tracks are: "Guitar", "Rhythm", "Bass", "Vocal", "Drum1", "Drum2", "Drum3" and "Drum4"
 
 Example:
 
@@ -218,13 +218,13 @@ BGCHANGE format:
 - beat: The beat this BGCHANGE occurs on. Can be negative to start before the first beat.
 - file_or_folder: The relative path to the file to use for the BGCHANGE. Lua files are allowed. If a folder is given, it looks for "default.lua".
 - update_rate: The update rate of the BGCHANGE.
-- crossfade: set to 1 if using a crossfade. Overriden by Effect.
-- stretchrewind: set to 1 if using stretchrewind. Overriden by Effect.
-- stretchnoloop: set to 1 if using stretchnoloop. Overriden by Effect.
+- crossfade: set to 1 if using a crossfade. Overridden by Effect.
+- stretchrewind: set to 1 if using stretchrewind. Overridden by Effect.
+- stretchnoloop: set to 1 if using stretchnoloop. Overridden by Effect.
 - Effect: What BackgroundEffect to use.
 - File2: The second file to load for this BGCHANGE.
 - Transition: How the background transitions to this.
-- Color1/Color2: Formatted as `red^green^blue^alpha`, with the values being from 1 to 0, Passed to the BackgroundEffect with the LuaThreadVaraible "Color1"/"Color2" in web hexadecimal format as a string. Alpha is optional.
+- Color1/Color2: Formatted as `red^green^blue^alpha`, with the values being from 1 to 0, Passed to the BackgroundEffect with the LuaThreadVariable "Color1"/"Color2" in web hexadecimal format as a string. Alpha is optional.
 
 Often, a last entry with "-nosongbg-" as the file is placed so the song's starting background doesn't show up at the end.
 
@@ -253,7 +253,7 @@ The second line explained: `52.000=blossom2.jpg=1.000=0=0=1=====`
 - Color2: none
 ---
 ## ``FGCHANGES``
-Like BGCHANGES, FGCHANGES follow the same format, but happen in a Foregound layer, above the players and most everything else. Commonly used in gimmick files to script modifiers or other visual aspects.
+Like BGCHANGES, FGCHANGES follow the same format, but happen in a Foreground layer, above the players and most everything else. Commonly used in gimmick files to script modifiers or other visual aspects.
 
 Example:
 
@@ -375,7 +375,7 @@ There are two special cases involving the Hard difficulty. If the description is
 
 ### Note layout
 
-Each measure has a minumum of four lines, with each measure being comma separated. The number of characters per row corresponds to the number of columns the mode has. (eg: dance-single has four columns, so each row has four characters)
+Each measure has a minimum of four lines, with each measure being comma separated. The number of characters per row corresponds to the number of columns the mode has. (eg: dance-single has four columns, so each row has four characters)
 
 4 rows per measure allows for 4ths, 8 rows per measure allows for 8ths, 16 rows per measure allows for 16ths, etc.
 
@@ -394,7 +394,7 @@ L|Lifts|N/A
 F|Fakes|They can only be fake taps. You can't do fake holds with this.
 
 ### Attack Notes
-Attacks can be attatched to notes by having `{}` after the note.
+Attacks can be attached to notes by having `{}` after the note.
 
 The format is `{modstring:lengthseconds}`
 

--- a/dev/mode-support/tja-support.md
+++ b/dev/mode-support/tja-support.md
@@ -113,7 +113,7 @@ SEVOL:100
 ```
 ---
 ## ``DEMOSTART``
-This allows for the preview of the song file set in ``WAVE``. It is set to play when in screen select music, (The music wheel) and will play from the point chosen here. This system mimicks the ``#PREVIEW`` system in BMS, but does not require you to load two files. It simply uses the one song file, and will play from the point selected.
+This allows for the preview of the song file set in ``WAVE``. It is set to play when in screen select music, (The music wheel) and will play from the point chosen here. This system mimics the ``#PREVIEW`` system in BMS, but does not require you to load two files. It simply uses the one song file, and will play from the point selected.
 
 You need to set a time within the file, or this can cause issues with some simulators. If your song file was 93 seconds long, and you set ``DEMOSTART:99``, this can cause undesirable behaviour in other simulators. If the number is invalid in OutFox, it will just play from the beginning, so do set this right!
 

--- a/dev/mods/Mods-1-Speed-Mods.md
+++ b/dev/mods/Mods-1-Speed-Mods.md
@@ -121,15 +121,15 @@ PlayerOptions format: ScrollBPM(\<BPM value\>, \<approach rate\>)
 
 Example: `ScrollBPM(1, 2)`
 
-## AvarageScrollBPM
+## AverageScrollBPM
 Desc: This is the underlying BPM value that AMod uses. When this is zero, AMod is turned off.
 Common values are the same as those for AMod.
 
 Quirks: Like the BPM-based speed mods, the magnitude is often in the 100s, so a larger approach rate might be needed.
 
-PlayerOptions format: AvarageScrollBPM(\<BPM value\>, \<approach rate\>)
+PlayerOptions format: AverageScrollBPM(\<BPM value\>, \<approach rate\>)
 
-Example: `AvarageScrollBPM(200, 0.5)`
+Example: `AverageScrollBPM(200, 0.5)`
 
 ## MaxScrollBPM
 Desc: This is the underlying BPM value that MMod uses. When this is zero, MMod is turned off, and AMod is able to be used.

--- a/dev/mods/Mods-11-ModSplines.md
+++ b/dev/mods/Mods-11-ModSplines.md
@@ -18,7 +18,7 @@ Point and column numbering start at 1 in SM5, while it starts at 0 in NotITG.
 
 To stop the current chain of spline points, a 'null point' (Where both position and magnitude are at zero) can be used as a 'null terminator' or sorts. This is only applicable for points after the first.
 
-The following types are avaiable for modsplines (designated as `<axis>`):
+The following types are available for modsplines (designated as `<axis>`):
 - X (Positioning on the x axis, affects receptors & notes. Works in multiples of ARROW_SIZE)
 - Y (Positioning on the y axis, affects receptors & notes. Works in multiples of ARROW_SIZE. The quirks of SpiralY apply here if holds or rolls are involved.)
 - Z (Positioning on the z axis, affects receptors & notes. Works in multiples of ARROW_SIZE)
@@ -26,7 +26,7 @@ The following types are avaiable for modsplines (designated as `<axis>`):
 - RotY (Rotation on the y axis, affects notes only. Works in radians. Known as "RotationY" in NotITG, but uses RotY for functions. Also affects hold heads in SM5 without extra mods needed.)
 - RotZ (Rotation on the z axis, affects notes only. Works in radians. Known as "RotationZ" in NotITG, but uses RotZ for functions. Also affects hold heads in SM5 without extra mods needed.)
 - Zoom (Zoom all three axis with the Mini calculations, affects receptors & notes. Known as "Size", "Tiny" (Modstring only) or "Zoom" (Modstring only) in NotITG)
-- SkewX (Aribtrary amounts of skewx, affects receptors & notes. Works like NoteSkewX. Known as "Skew" in NotITG)
+- SkewX (Arbitrary amounts of skewx, affects receptors & notes. Works like NoteSkewX. Known as "Skew" in NotITG)
 - SkewY (Arbitrary amounts of skewy, affects receptors & notes. Works like NoteSkewY. Not available in NotITG v4.0)
 - Stealth (Arbitrary amounts of stealth.)
 

--- a/dev/mods/Mods-13-Miscellaneous-Mods.md
+++ b/dev/mods/Mods-13-Miscellaneous-Mods.md
@@ -20,7 +20,7 @@ Modstring format: clearall
 ## HoldGrainMult
 Desc: Adds a multiplier to the 'step size' of holds, allowing one to control how 'granular' a hold is. In NotITG, this is known as "granulate" or "grain" (alias).
 
-Negative values make the hold smoother (with a 'limit' of -93.75% which results in a step size of 1 pixel), but could cost performance due to the extra calculations being done. Positive values make the hold look more polygonal (with no real limit). Very noticable on modifiers that work on position, like Drunk.
+Negative values make the hold smoother (with a 'limit' of -93.75% which results in a step size of 1 pixel), but could cost performance due to the extra calculations being done. Positive values make the hold look more polygonal (with no real limit). Very noticeable on modifiers that work on position, like Drunk.
 
 Common values can range from practically anywhere due to it being a multiplier. Try starting with -50% or 100% and go further if extra points or less points are desired.
 
@@ -228,7 +228,7 @@ Desc: Performs clipping on the trigonometric waves used in many modifiers and th
 
 The following are available:
 - SinClip (sine wave clipping. Affects Wave (all non-tan variants), SpiralY, Bumpy (all non-tan variants), Beat (all variants), Zigzag (All variants), Digital (All non-tan variants), Bounce (All variants), Blink (All variants), Pulse (all non-tan variants),
-- CosClip (cosine wave clipping. Affects Tornado (all non-tan varians), Tipsy (all non-tan variants), Expand, Drunk (all non-tan variants), SpiralX
+- CosClip (cosine wave clipping. Affects Tornado (all non-tan variants), Tipsy (all non-tan variants), Expand, Drunk (all non-tan variants), SpiralX
 - TanClip (tangent wave clipping, use values close to 100% for visible effects. Affects all tangent variants of all modifiers)
 
 Quirks: Going beyond 100% may result in interesting effects on some modifiers. In NotITG, this was 'fixed'.
@@ -340,7 +340,7 @@ PlayerOptions format: NoteSkinCol(\<column\>, \<noteskin name\>)
 
 Example: `NoteSkinCol(nil, 'lambda')`
 
-Modstring format: \<noteskin name\> noteskin\<column\> (ommitting column will hit all columns)
+Modstring format: \<noteskin name\> noteskin\<column\> (omitting column will hit all columns)
 
 Example: `lambda noteskin`
 

--- a/dev/mods/Mods-2-Perspective-Mods.md
+++ b/dev/mods/Mods-2-Perspective-Mods.md
@@ -8,12 +8,12 @@ editor: markdown
 dateCreated: 2023-05-16T06:18:06.975Z
 ---
 
-Perspective modifiers tilt and skew the notefield itself to allow for a feeling of depth. Scripted modfiles can use these to do effects like rocking the notefield back and forth among other effects (And is definitely noticable with 3D noteskins).
+Perspective modifiers tilt and skew the notefield itself to allow for a feeling of depth. Scripted modfiles can use these to do effects like rocking the notefield back and forth among other effects (And is definitely noticeable with 3D noteskins).
 
-Unlike most modifiers available through PlayerOptions, these functions only return values in terms of tilt and skew and don't return the current/previous approach rate. Perspecitve modifiers aren't column-specific either.
+Unlike most modifiers available through PlayerOptions, these functions only return values in terms of tilt and skew and don't return the current/previous approach rate. Perspective modifiers aren't column-specific either.
 
 ## Hallway
-Desc: The notefield is tilted away from the player, so that notes start far away and come closer. Very noticable with 3D noteskins.
+Desc: The notefield is tilted away from the player, so that notes start far away and come closer. Very noticeable with 3D noteskins.
 
 Tilt is negative, while Skew is at zero.
 
@@ -34,7 +34,7 @@ Example: `*1 150% hallway`
 <video class="normal-scale-video" src="/resources/guide-to-modifiers/perspective/hallway.webm" controls="">Distant video example</video>
 
 ## Distant
-Desc: The notefield is tilted towards the player, so that notes start close to the screen and go away. Very noticable with 3D noteskins.
+Desc: The notefield is tilted towards the player, so that notes start close to the screen and go away. Very noticeable with 3D noteskins.
 
 Tilt is positive, while Skew is at zero.
 

--- a/dev/mods/Mods-3-Column-Movement-Mods.md
+++ b/dev/mods/Mods-3-Column-Movement-Mods.md
@@ -94,7 +94,7 @@ Example: `*3 150% tipsy` `*3 150% tantipsy`
 ## TipsyOffset
 Desc: TipsyOffset shifts the point in time of where Tipsy is in its' sinusoidal pattern.
 
-Values of -100 to 100% have a noticable effect.
+Values of -100 to 100% have a noticeable effect.
 
 Available Variants: TipsyOffset, TanTipsyOffset
 
@@ -103,7 +103,7 @@ Available Variants (modstring): tipsyoffset, tantipsyoffset
 ## TipsySpacing
 Desc: TipsySpacing shifts the phase for each column after the first column.
 
-Values of -100 to 100% have a noticable effect.
+Values of -100 to 100% have a noticeable effect.
 
 Available Variants: TipsySpacing, TanTipsySpacing
 

--- a/dev/mods/Mods-6-Zoom-Mods.md
+++ b/dev/mods/Mods-6-Zoom-Mods.md
@@ -83,9 +83,9 @@ Modstring format: \<enable\> tinyusesminicalc
 ## Pulse
 Desc: Pulse is a set of mods that make the notes zoom in and out as they approach the receptors.
 
-PulseOuter affects the main pulsing effect, while PulseInner offsets the maximum & minumum zoom. Also has a tangent-based variant.
+PulseOuter affects the main pulsing effect, while PulseInner offsets the maximum & minimum zoom. Also has a tangent-based variant.
 
-PulseOuter is noticable at 100%, and 100% PulseInner offsets the zoom to between 2x and 1x zoom.
+PulseOuter is noticeable at 100%, and 100% PulseInner offsets the zoom to between 2x and 1x zoom.
 
 Quirks: N/A
 
@@ -120,7 +120,7 @@ Desc: Affects the speed of the pulsing with a multiplier (1 + magnitude).
 
 Positive magnitudes slow down the pulsing, negative magnitudes speed it up.
 
--100% freezes the effect at the minumum.
+-100% freezes the effect at the minimum.
 
 Available Variants: PulsePeriod, TanPulsePeriod
 

--- a/dev/mods/Mods-9-Path-Mods.md
+++ b/dev/mods/Mods-9-Path-Mods.md
@@ -15,7 +15,7 @@ Desc: Drunk makes the notes and receptors move left and right in a constantly sh
 
 Common values can be practically any value, due to its' wide use in modfiles. Try starting with -200 to 200% for an initial effect.
 
-Quirks: When combined with Tipsy in SM5.1 and earlier, hold bodies may detatch from the hold head. The phase of the sinusoidal wave depends on game uptime unless the mod timer is changed.
+Quirks: When combined with Tipsy in SM5.1 and earlier, hold bodies may detach from the hold head. The phase of the sinusoidal wave depends on game uptime unless the mod timer is changed.
 
 Available variants: Drunk, DrunkY, DrunkZ, TanDrunk, TanDrunkY, TanDrunkZ
 
@@ -145,7 +145,7 @@ Example: `*0.2 100% tornado`
 
 ### Available sub modifiers:
 ## TornadoOffset
-Desc: Offsets the phase of the sinusoidal curves for each column. Large values are needed for noticable effects.
+Desc: Offsets the phase of the sinusoidal curves for each column. Large values are needed for noticeable effects.
 
 Available variants: TornadoOffset, TornadoZOffset, TanTornadoOffset, TanTornadoZOffset
 
@@ -555,7 +555,7 @@ PlayerOptions format: AsymptoteOffset(\<magnitude\>, \<approach rate\>)
 Modstring format: *\<approach rate\> \<magnitude\> asymptoteoffset
 
 ## AsymptoteScale
-Desc: Affects the curve before veering off towards the asymptote. Negative values make the curve more noticable. Going past -100% flips the curve. Being at -100% hides the notefield. (Has an alias of "asymptotesize" in NotITG)
+Desc: Affects the curve before veering off towards the asymptote. Negative values make the curve more noticeable. Going past -100% flips the curve. Being at -100% hides the notefield. (Has an alias of "asymptotesize" in NotITG)
 
 PlayerOptions format: AsymptoteScale(\<magnitude\>, \<approach rate\>)
 

--- a/dev/mods/_index.md
+++ b/dev/mods/_index.md
@@ -35,7 +35,7 @@ First off:
 1. **Open a Simfile** in the Outfox editor **(Title Screen > Edit/Share > Edit Songs/Steps)**. Pick a song, then pick a difficulty (chart).
 
 2. When editing the chart, press **Enter** where you want the Modifier to start.
-3. Choose **Modifiy attacks at current beat** at the bottom of the menu.
+3. Choose **Modify attacks at current beat** at the bottom of the menu.
 
 ![mods-attacks-enter-menu.png](/resources/guide-to-modifiers/mods-attacks-enter-menu.png){.align-center}
 
@@ -65,7 +65,7 @@ Attacks only last a few seconds by default - to **make it last longer** you'll n
 3. From here, press **Enter** on any of these options to change them:
 
    * Starting time: When this attack starts. It's better to remove/re-add an attack if you want to change when it starts.
-   * Seconds Remaining: How long the attack lasts (defalt: 5 seconds)
+   * Seconds Remaining: How long the attack lasts (default: 5 seconds)
    * Attack 1: The mod you just added - press enter to change
    * Add Mod: Pick this to add another mod to this attack
 

--- a/dev/outfoxonline/onlineoverlay.md
+++ b/dev/outfoxonline/onlineoverlay.md
@@ -14,7 +14,7 @@ The online overlay runs on [ScreenSystemLayer](/en/dev/screens/ScreenSystemLayer
 
 The full name for this file is called: `ScreenSystemLayer ofonline.lua`, and is present on the BGAnimations folder.
 
-By default it sits dormant on each side of the screen for each player, and upon receiveing notifications, it runs a command to determine what to report back to the players.
+By default it sits dormant on each side of the screen for each player, and upon receiving notifications, it runs a command to determine what to report back to the players.
 
 ![ofonlineoverlayconnectd.png](/dev/outfoxonline/ofonlineoverlayconnectd.png){.align-center}
 
@@ -22,7 +22,7 @@ The command received is a MessageCommand called `MessageOFNetworkResponse`. In t
 
 | Title | Type | Description |
 | --- | --- | --- |
-Name | String | The name of the command that it just receieved.
+Name | String | The name of the command that it just received.
 PlayerNumber | PlayerNumber | The player this command belongs to.
 Status | String | Depending on the command, this variable can return a `success` or `error` based on the output of the response.
 Message | String | An optional variable which outputs a reason, normally present alongside an error status.

--- a/dev/screens/Screen.md
+++ b/dev/screens/Screen.md
@@ -63,7 +63,7 @@ GroupedScreens="ScreenMenu,ScreenSubMenu"
 ## Case 3: Entering ungrouped screens.
 
 If a screen is added to the screen stack that isn't in the current screen **Group** (which is done by using `GroupedScreens`),
-the screen group is reset. All prepared screens are unloaded and the persistance list is erased.
+the screen group is reset. All prepared screens are unloaded and the persistence list is erased.
 
 An example:
 

--- a/dev/screens/ScreenAttract.md
+++ b/dev/screens/ScreenAttract.md
@@ -18,7 +18,7 @@ When the screen is set to this class/fallback, the
 # Available Metrics
 | Name | Default Value | Description |
 | --- | --- | --- |
-| BackGoesToStartScreen | true | Changes the behaviour for the back button to use the NextScreen insted of PrevScreen. |
+| BackGoesToStartScreen | true | Changes the behaviour for the back button to use the NextScreen instead of PrevScreen. |
 | ResetGameState | false | Requests the game to reset GameState. |
 | AttractVolume | 1 | Sets the starting volume for the screen. |
 

--- a/dev/screens/ScreenDebugOverlay.md
+++ b/dev/screens/ScreenDebugOverlay.md
@@ -8,7 +8,7 @@ editor: markdown
 dateCreated: 2024-01-21T22:46:06.091Z
 ---
 
-The debug overlay is one of the Overlay Screens run by the game. It is reponsible for access to several utilities in the case of theme debugging, logic testing, and arcade operation.
+The debug overlay is one of the Overlay Screens run by the game. It is responsible for access to several utilities in the case of theme debugging, logic testing, and arcade operation.
 
 ![screendebugoverlay-showcase.png](/dev/screens/screendebugoverlay/screendebugoverlay-showcase.png)
 

--- a/dev/screens/ScreenNetworkOptions.md
+++ b/dev/screens/ScreenNetworkOptions.md
@@ -34,7 +34,7 @@ The dedicated connection button to connect to OutFox Online. Upon interacting wi
 An option to auto connect to OutFox Online when the game starts up. Disabled by default.
 
 ## Enable Discord Rich Presence
-Enables Rich Presence functionality for Discord, which makes gameplay info be dislayed on your Discord profile while the game is on. These will update information depending on which screen you are.
+Enables Rich Presence functionality for Discord, which makes gameplay info be displayed on your Discord profile while the game is on. These will update information depending on which screen you are.
 
 > You must restart the game for this option to take effect.
 {.is-info}

--- a/dev/screens/ScreenOptions.md
+++ b/dev/screens/ScreenOptions.md
@@ -45,7 +45,7 @@ By default, the game will provide you with a 5-button individual navigation mode
 
 However, if the need requires to use the classic 3-button navigation mode where movement was performed only using Left, Right and Start, you can switch the `NavigationMode` metric to `toggle`. This brings back the "Scroll Down" button, located on the start of every row, which allows you to move to the next row without modifying values.
 
-> If the `NagivationMode` is set to `toggle`, you may notice that the "Scroll Down" **may not show up**. This is due to the game checking for a preference called `ArcadeOptionsNavigation` *(Otherwise known as Options Navigation in Input Options)*.
+> If the `NavigationMode` is set to `toggle`, you may notice that the "Scroll Down" **may not show up**. This is due to the game checking for a preference called `ArcadeOptionsNavigation` *(Otherwise known as Options Navigation in Input Options)*.
 > Unless this preference is set to "Arcade Mode" it will not apply the "Scroll Down" button.
 >{.is-warning}
 

--- a/dev/screens/ScreenProfileLoad.md
+++ b/dev/screens/ScreenProfileLoad.md
@@ -1,6 +1,6 @@
 ---
 title: ScreenProfileLoad
-description: Reponsible for automating the process of loading the profiles in a safe manner.
+description: Responsible for automating the process of loading the profiles in a safe manner.
 published: true
 date: 2024-01-21T23:37:49.122Z
 tags: 
@@ -11,7 +11,7 @@ dateCreated: 2024-01-21T23:36:29.893Z
 > Depends on [ScreenWithMenuElementsBlank]().
 {.is-info}
 
-This screen is reponsible for automating the process of loading the profiles in a safe manner.
+This screen is responsible for automating the process of loading the profiles in a safe manner.
 
 Only a metric is used here to toggle a setting:
 ```ini

--- a/dev/theming.md
+++ b/dev/theming.md
@@ -21,7 +21,7 @@ This guide will comprise of the process on how to create such theme from scratch
 # Chapter 1: Introduction
 
 - [Theming differences between older versions *It is important to note the following aspects when starting to make your theme.*](Theming-0-Differences)
-- [The Structure of folders *Learn how to structure your theme with the appropiate content folders.*](Theming-1-Folders)
+- [The Structure of folders *Learn how to structure your theme with the appropriate content folders.*](Theming-1-Folders)
 {.links-list}
 
 # Chapter 2: Screens and actors
@@ -57,7 +57,7 @@ This guide will comprise of the process on how to create such theme from scratch
 - [Creating a custom screen *A more advanced topic, where you can create your own screens to do anything with.*](Theming-2-Screen-Creation)
 - [Custom Input *An addendum to making a custom screen, learn how to make your own input so you can interact with your new content!*](Theming-Custom-Input)
 - [Modules *A system that allows on-demand functions/snippets to be loaded.*](Theming-Modules)
-- [Theming tips and tricks *Miscelaneous tips you can check out for your theme.*](tips)
+- [Theming tips and tricks *Miscellaneous tips you can check out for your theme.*](tips)
 {.links-list}
 
 *Guide Written and Maintained by Jose_Varela.*

--- a/dev/theming/3d-perspective.md
+++ b/dev/theming/3d-perspective.md
@@ -1,6 +1,6 @@
 ---
 title: 3D Perspectives on Actors
-description: This document will go into detail about setting up an ActorFrame to perform operations that resemble a 3D enviroment.
+description: This document will go into detail about setting up an ActorFrame to perform operations that resemble a 3D environment.
 published: true
 date: 2025-05-31T07:53:23.581Z
 tags: 
@@ -23,7 +23,7 @@ For this, we need to describe some quirks about 3D in Project OutFox (and other 
 
 # Adjusting the FOV
 
-To adjust the FOV on your enviroment [ActorFrame](/en/dev/actors/actortypes/actorframe), you have two options:
+To adjust the FOV on your environment [ActorFrame](/en/dev/actors/actortypes/actorframe), you have two options:
 
 - Adjust the FOV attribute on the [Def.ActorFrame](/en/dev/actors/actortypes/actorframe) object.
 - Use the `self:fov` function on said [ActorFrame](/en/dev/actors/actortypes/actorframe).
@@ -40,7 +40,7 @@ To adjust the draw distance, we make use of the `fardistz` function, available f
 self:fardistz(3000) -- This will set it to 3000px.
 ```
 
-# First-Person Enviroment Example
+# First-Person Environment Example
 
 To perform this kind of 3D projection, we'll be performing a trick that's usually shown in 3D rendering where the "Camera" - which is what the user is seeing - is completely stationary, and instead, the entire world (objects and all) are moving relative to that camera.
 
@@ -104,7 +104,7 @@ local rad = math.pi/180
 local cam = Vector3.new(0,0,0)
 ```
 
-Since the "Camera" in Project OutFox doesn't ever move, we'll do a technique were an [ActorFrame](/en/dev/actors/actortypes/actorframe) will pretend to the camera, and another one, the enviroment that it will project from.
+Since the "Camera" in Project OutFox doesn't ever move, we'll do a technique were an [ActorFrame](/en/dev/actors/actortypes/actorframe) will pretend to the camera, and another one, the environment that it will project from.
 
 ```lua
 --[[
@@ -123,7 +123,7 @@ local EnvCamera = Def.ActorFrame{
     end
 }
 
-local Enviroment = Def.ActorFrame{
+local Environment = Def.ActorFrame{
 		FOV=90,
     OnCommand=function (self)
         self:fardistz(9e9)

--- a/dev/theming/Theming-0-Differences.md
+++ b/dev/theming/Theming-0-Differences.md
@@ -69,7 +69,7 @@ end
 
 ### Some bugs to point out from CMD
 
-- `self` cannot be utilized to obtain itself as `self` is a non-existant object in its scope.
+- `self` cannot be utilized to obtain itself as `self` is a non-existent object in its scope.
 
 ```lua
 -- This will fail because the engine doesn't know what self is in this scope.

--- a/dev/theming/Theming-1-Folders.md
+++ b/dev/theming/Theming-1-Folders.md
@@ -10,7 +10,7 @@ dateCreated: 2023-05-16T06:18:46.002Z
 
 A theme can consist of the following folders. All of them are optional, but needed to perform certain operations on how to load / fetch files.
 
-It is important to understand that themes in newer versions of StepMania/OutFox rely on `_fallback`, a special theme folder located on `Appearance/Themes/` which contains all of the information neccessary to run any kind of theme. Earlier in the day, since there was no such thing, every theme distributed had to contain the same information in order to run, which in term would lead to a lot of repeated code for something that was never used.
+It is important to understand that themes in newer versions of StepMania/OutFox rely on `_fallback`, a special theme folder located on `Appearance/Themes/` which contains all of the information necessary to run any kind of theme. Earlier in the day, since there was no such thing, every theme distributed had to contain the same information in order to run, which in term would lead to a lot of repeated code for something that was never used.
 
 You can create more/less folders than this and call them in your theme by fetching the location of your theme's folder
 and then accessing the data that you need, but for the purposes of this guide, we'll stick to these folders.

--- a/dev/theming/Theming-2-Screen-Creation.md
+++ b/dev/theming/Theming-2-Screen-Creation.md
@@ -27,7 +27,7 @@ As you notice, we're using the `Fallback` item. This is to have an existing scre
 > Every single screen created **must** contain some kind of class, otherwise the engine will not know how to respond to it and crash or send out an error. If you are unsure which class to use, you can rely on **ScreenWithMenuElements**, as it is the most basic screen class type, and the skeleton for every other class.
 {.is-warning}
 
-## Acessing the screen
+## Accessing the screen
 
 Now with the metric information added, we have to have a way to enter the screen. There are mainly 3 ways to send the user to the screen.
 

--- a/dev/theming/Theming-3-Anatomy-Screen.md
+++ b/dev/theming/Theming-3-Anatomy-Screen.md
@@ -49,7 +49,7 @@ A specifically-visual layer, where objects can be placed for decorations. Most a
 
 ### In / Out / Cancel
 
-Pure visual layers that serve as entrace, exit and backing out of a screen respectively.
+Pure visual layers that serve as entrance, exit and backing out of a screen respectively.
 They are run as soon as the screen has to perform a change that will end up unloading itself.
 - Lua based input is not available on this layer, as no input is ever sent.
 - For **Cancel**, the transition command to run the animation uses `StartTransitioningCommand`. Using OnCommand or InitCommand will

--- a/dev/theming/Theming-4-Creating-Font.md
+++ b/dev/theming/Theming-4-Creating-Font.md
@@ -60,7 +60,7 @@ The smaller window area provides info into what font to use, its size to render,
 
 **Page**: is the glyph map to render out with the current font.
 
-> It is recommended to use a monospaced font for GUI elements, as it allows readability and accesibility for dyslexic individuals.
+> It is recommended to use a monospaced font for GUI elements, as it allows readability and accessibility for dyslexic individuals.
 {.is-info}
 
 The tool allows for different kinds of options on what glyphs to export, which are the following:

--- a/dev/theming/Theming-Custom-Input.md
+++ b/dev/theming/Theming-Custom-Input.md
@@ -59,7 +59,7 @@ return Def.ActorFrame{
 
 # Anatomy of the event variable
 
-When recieving input, you will be given a table by the name of `event`. It gives you base elements, which contain all the information you need to determine what the user has performed to then report back to the theme.
+When receiving input, you will be given a table by the name of `event`. It gives you base elements, which contain all the information you need to determine what the user has performed to then report back to the theme.
 
 Name | Returns | Description |
 :------------ | :------ | :---------- |
@@ -77,7 +77,7 @@ Inside this table, is another table called `DeviceInput` (can be accessed from `
 Name | Returns | Description |
 :------------ | :------ | :---------- |
 device | string | Type of the device, which will start with `"Device_"`, and then followed with a InputDeviceNames entry.
-button | string | The button that was pressed, which will start with `"DeviceButton_"`, and then followed with the key correspondant on the device.
+button | string | The button that was pressed, which will start with `"DeviceButton_"`, and then followed with the key correspondent on the device.
 level | float | A floating point value for analog input.
 z | float | A floating point value for determining what level is the mousewheel at.
 down | bool | Determines if the button is down. This is a combination of level with a threshold. and debouncing applied.
@@ -188,7 +188,7 @@ OnCommand = function(self)
 	SCREENMAN:GetTopScreen():AddInputCallback( self.callback )
 end,
 -- And now, when leaving, it will have the right actor to remove.
-OffCommmand = function(self)
+OffCommand = function(self)
 	SCREENMAN:GetTopScreen():RemoveInputCallback( self.callback )
 end
 ```

--- a/dev/theming/Theming-Scripts.md
+++ b/dev/theming/Theming-Scripts.md
@@ -8,7 +8,7 @@ editor: markdown
 dateCreated: 2023-05-16T06:19:08.651Z
 ---
 
-Introduced in StepMania 3.95, Scripts are Lua files that are loaded globally to the engine. These are always available to use, from anywhere in the theme. However, it is advised to **use these sparingly** to avoid unnecesary carry over of data, overlapping variable names with other existing Lua naming scopes, and others.
+Introduced in StepMania 3.95, Scripts are Lua files that are loaded globally to the engine. These are always available to use, from anywhere in the theme. However, it is advised to **use these sparingly** to avoid unnecessary carry over of data, overlapping variable names with other existing Lua naming scopes, and others.
 
 It is recommended practice to ensure script data is kept to a minimum to avoid collision with objects like song data, scores, player data, mods, profile information, song rates, and others.
 
@@ -16,9 +16,9 @@ An example of a script file can be the following:
 ```lua
 MyGlobalObject = {}
 
--- Add some objets to this variable.
+-- Add some objects to this variable.
 MyGlobalObject.CustomFunction = function( val )
-	SCREENMAN:SystemMessage( "I've just recieved ".. val )
+	SCREENMAN:SystemMessage( "I've just received ".. val )
 end
 ```
 

--- a/dev/theming/stylebackground.md
+++ b/dev/theming/stylebackground.md
@@ -26,7 +26,7 @@ Once you save the file, restart the game again (faster reloading methods will be
 
 We've just made our own background layer, very nice. But now try to change the color on it. Try for example: `Color.Blue`. Have you noticed something? Maybe that the color isn't updating?
 
-This is because the background is special, where it is always running as long as the screen is correspondant to the screen is defined in, so, as long as you're in ScreenTitleMenu, no matter how many times you reload it, it will run the same background from where it was. This is done to make seamless playback while switching screens.
+This is because the background is special, where it is always running as long as the screen is correspondent to the screen is defined in, so, as long as you're in ScreenTitleMenu, no matter how many times you reload it, it will run the same background from where it was. This is done to make seamless playback while switching screens.
 
 But what if you want to see the changes? Well, this is where we're going to introduce our first helper: The creator menu!
 

--- a/dev/theming/tips.md
+++ b/dev/theming/tips.md
@@ -11,8 +11,8 @@ dateCreated: 2023-05-16T06:19:19.214Z
 This section is meant to showcase methods to create certain kinds of actors and recommended practices that are commonly found in themes.
 
 ## Verifying Command availability
-<!-- [Verifying Commmand availability](cmdavailable.md) -->
-While developing a theme, you may come across commands and functions that are available for current or future versions of OutFox, however it is recommended to make sure that your theme is still compatible for users that run older versions of OutFox or StepMania, and this can be done via a check for its existance.
+<!-- [Verifying Command availability](cmdavailable.md) -->
+While developing a theme, you may come across commands and functions that are available for current or future versions of OutFox, however it is recommended to make sure that your theme is still compatible for users that run older versions of OutFox or StepMania, and this can be done via a check for its existence.
 
 Let's say for example that you want to use the `GetTotalScoresWithGrade` Profile function that is available in OutFox Alpha 4.15.
 That command is not available on previous versions nor in StepMania, so you can use an if check to verify that it exists.
@@ -30,7 +30,7 @@ if myProfile.GetTotalScoresWithGrade then
 end 
 ```
 
-When running OutFox Alpha 4.15 or higher, you'll recieve the message "Command Available!" when executed; while any other 
+When running OutFox Alpha 4.15 or higher, you'll receive the message "Command Available!" when executed; while any other 
 build will not report the message given it's not available on the Profile namespace.
 
 You can also use this search when assigning values to provide a failsafe value in the case the function is not available via a ternary operator.
@@ -42,7 +42,7 @@ local GradedScores = myProfile.GetTotalScoresWithGrade and myProfile:GetTotalSco
 ## Make sure to cover edge cases for commands
 This is a specially common case on the Music Wheel. A fundamental change was done around the 5.0.11 era that remove the wheel verification
 for items, making the themes responsible of dealing with such task. So in the case arrives where items need to be fetched, make sure to verify
-that the Index/Song/Course you're obtaining for the SongWheelItem is not null; otherwise you'll start recieving a lot of error messages.
+that the Index/Song/Course you're obtaining for the SongWheelItem is not null; otherwise you'll start receiving a lot of error messages.
 
 ```lua
 -- Let's say you have a text actor that will display the name of the song of the current item on the wheel.

--- a/dev/translation.md
+++ b/dev/translation.md
@@ -36,7 +36,7 @@ Now open en.ini and your new language file, then copy all the content from en.in
 
 The language code used for your language file should follow [ISO-1 Language codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), while the COUNTRY CODE should follow [ISO 3166-1 Alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements).
 
-> ⚠️ StepMania Engine doesn't have proper support for more than 2 letters language files: Both StepMania and OutFox, as the date of writting this document, do not follow ISO-1 and ISO 3166-1 standards, however, new languages should not abide by non-standards of StepMania Engine quirks. Your language will still be able to be selected and used, however, instead of showing the Language name, it will show the language code and users won't have the game auto-select the language for them. This will later be fixed at least for OutFox, [following this issue](https://github.com/TeamRizu/OutFox/issues/311).
+> ⚠️ StepMania Engine doesn't have proper support for more than 2 letters language files: Both StepMania and OutFox, as the date of writing this document, do not follow ISO-1 and ISO 3166-1 standards, however, new languages should not abide by non-standards of StepMania Engine quirks. Your language will still be able to be selected and used, however, instead of showing the Language name, it will show the language code and users won't have the game auto-select the language for them. This will later be fixed at least for OutFox, [following this issue](https://github.com/TeamRizu/OutFox/issues/311).
 {.is-danger}
 
 
@@ -50,7 +50,7 @@ WindowTitle=Project OutFox
 StepMania=Project OutFox
 # Dedicated Character Display strings
 ModelLoadError=Model for %s (%s) Has a invalid model. Please check if the model.txt file is correctly named and formatted.
-ModelAnimLoadError=An animation file for %s's model (%s) is invalid or non-existant. Please check the animation folders and see if there's any file missing.
+ModelAnimLoadError=An animation file for %s's model (%s) is invalid or non-existent. Please check the animation folders and see if there's any file missing.
 LocationLoadError=Current Location (%s) is missing its location model. Please check if the model.txt file is correctly named and formatted.
 SongLoaderSingleSong=Random Song Play: Current Folder only contains 1 song. OutFox might get confused when picking the song via random. Selecting to index 1.
 SongLoaderNoSongs=Random Song Play: No songs were found in your OutFox install folder! Switching back to fallback music.

--- a/user-guide/config/connecting-online.md
+++ b/user-guide/config/connecting-online.md
@@ -70,5 +70,5 @@ To generate the pin, head over to https://outfox.online/dashboard/profiles (or s
 
 And voila! Your profile has now been loaded on the cabinet, and you play as normal. All scores made during the session will be saved to your account, along with any mods you've setup during the session, which will be carried over for next time when you play on the same cabinet, or the computer you made the account on.
 
-> Some themes might not respect the modfiers you saved on OutFox Online (like Simply Love)! Please keep this in mind if some settings don't transfer during load.
+> Some themes might not respect the modifiers you saved on OutFox Online (like Simply Love)! Please keep this in mind if some settings don't transfer during load.
 {.is-warning}

--- a/user-guide/config/preferences.md
+++ b/user-guide/config/preferences.md
@@ -371,7 +371,7 @@ Default value: 0
 
 ### ConstantUpdateDeltaSeconds
 
-Experimantal feature that forces a specific update loop, in seconds. Having a value of ``0.0`` disables it.
+Experimental feature that forces a specific update loop, in seconds. Having a value of ``0.0`` disables it.
 
 Default value: 0.000000
 
@@ -447,7 +447,7 @@ Default value: 120.000000
 
 ### DDRStyleRandom
 
-When on, random backrounds use the song's directory as the seed, ensuring a conststent set of backgrounds for each song.
+When on, random backgrounds use the song's directory as the seed, ensuring a conststent set of backgrounds for each song.
 
 Possible values are ``0`` or ``1``. 0 is ``Off`` and 1 is ``On``.
 
@@ -493,7 +493,7 @@ Default value: nothing
 
 ### DefaultRecordLength
 
-How long a recording section in the editor is by defualt, in seconds.
+How long a recording section in the editor is by default, in seconds.
 
 Default value: 4.000000
 
@@ -857,7 +857,7 @@ Default value: 0
 
 ### HighResolutionTextures
 
-Set if high resoltuion textures are used. Not all themes support this. ``Auto`` makes high resolution happen if the window's height is greather than 480 pixels. Unused by the engine as a whole, but still has an enum for it.
+Set if high resoltuion textures are used. Not all themes support this. ``Auto`` makes high resolution happen if the window's height is greater than 480 pixels. Unused by the engine as a whole, but still has an enum for it.
 
 Possible values are ``Auto``, ``Force Off``, and ``Force On``.
 
@@ -1155,7 +1155,7 @@ Allows saving scores in a format made for Padmiss.
 
 Possible values are ``0`` or ``1``. 0 is ``Off`` and 1 is ``On``.
 
-Default vlaue: 0
+Default value: 0
 
 ### MemoryCardProfileImportSubdirs
 
@@ -1179,37 +1179,37 @@ Default value: 1
 
 The bus to use for reading P1's USB profile from.
 
-Defaut value: -1
+Default value: -1
 
 ### MemoryCardUsbBusP2
 
 The bus to use for reading P2's USB profile from.
 
-Defaut value: -1
+Default value: -1
 
 ### MemoryCardUsbLevelP1
 
 The level to use for reading P1's USB profile from.
 
-Defaut value: -1
+Default value: -1
 
 ### MemoryCardUsbLevelP2
 
 The level to use for reading P2's USB profile from.
 
-Defaut value: -1
+Default value: -1
 
 ### MemoryCardUsbPortP1
 
 The port to use for reading P1's USB profile from.
 
-Defaut value: -1
+Default value: -1
 
 ### MemoryCardUsbPortP2
 
 The port to use for reading P2's USB profile from.
 
-Defaut value: -1
+Default value: -1
 
 ### MemoryCards
 
@@ -1217,7 +1217,7 @@ Enables the memory card system, allowing USB profiles to be used.
 
 Possible values are ``0`` or ``1``. 0 is disabled and 1 is enabled.
 
-Defaut value: 0
+Default value: 0
 
 ### MenuTimer
 
@@ -1533,7 +1533,7 @@ Default value: nothing
 
 ### Python23IO_Mode
 
-The IO mode to use for the Pyton board.
+The IO mode to use for the Python board.
 
 Possible values are ``HDP3IO``, ``HDP2IO``, ``SDP2IO``, ``SDP3IOHDXB``, ``SDP3IO`` and ``none`.`
 
@@ -1667,7 +1667,7 @@ Default value: 1
 
 ### ShowDeltaClock
 
-Adds additional information about **frametime** to the top right of the screen. Those values can be used to view how much time your script (from Themes or modfiles) adds to the frametime, anything above 16ms is very slow and calls for optimization, the more consistant those values are, the better the game will feel.
+Adds additional information about **frametime** to the top right of the screen. Those values can be used to view how much time your script (from Themes or modfiles) adds to the frametime, anything above 16ms is very slow and calls for optimization, the more consistent those values are, the better the game will feel.
 
 Possible values are ``0`` or ``1``. 0 is "Hide" and 1 is "Show".
 
@@ -1803,7 +1803,7 @@ Default value: 0
 
 ### SongBackgrounds
 
-Show the backround of the song being played.
+Show the background of the song being played.
 
 Possible values are ``0`` or ``1``. 0 is ``Off`` and 1 is ``On``.
 

--- a/user-guide/games/gddm.md
+++ b/user-guide/games/gddm.md
@@ -99,6 +99,6 @@ This mode needed 'hidden lane' support. That is, two different note lanes occupy
 
 This mode simulates DTXMania, as there is more content for that simulator, and it follows a practice. There are _many_ forks of this project, so we spent some time with the community working out the features to add/discard from OutFox.
 
-The parser for this mode inherits a lot of the functionality of the `BMS` extended set, so OutFox by nature has a wider optional set of features due to this. One can also use `PMS`, or any other of the `BMS` derived parser features. We do not recommend this option if you want to keep your charts compatible with the orginal DTXMania of course!
+The parser for this mode inherits a lot of the functionality of the `BMS` extended set, so OutFox by nature has a wider optional set of features due to this. One can also use `PMS`, or any other of the `BMS` derived parser features. We do not recommend this option if you want to keep your charts compatible with the original DTXMania of course!
 
 _Written and Maintained with ♡ by Squirrel, with thanks to the DTXMania community; APPROVED, np\_sub and Furukon._

--- a/user-guide/games/pomu.md
+++ b/user-guide/games/pomu.md
@@ -89,7 +89,7 @@ File Type|Label|Original Mode|Key Values Supported|Notes
 
 ## Game play
 
-This mode is played default in down scroll, with the note receptors at the bottom of the screen. There is a selection of different coloured lanes that match a set colour on a large controller. The mode has been extended to support the obscure/rare modes that were charted and these have a slightly different colour layout to the standard 9 key mode. The little notes fall down to be pressed when the item reaches the receptor. This game mode can still play ``po-mu`` charts in BME/BML files, which was a common practice up until around 2014. Play is usually on a dome based button controller, layed out in a 4 top 5 bottom button arrangement. 
+This mode is played default in down scroll, with the note receptors at the bottom of the screen. There is a selection of different coloured lanes that match a set colour on a large controller. The mode has been extended to support the obscure/rare modes that were charted and these have a slightly different colour layout to the standard 9 key mode. The little notes fall down to be pressed when the item reaches the receptor. This game mode can still play ``po-mu`` charts in BME/BML files, which was a common practice up until around 2014. Play is usually on a dome based button controller, laid out in a 4 top 5 bottom button arrangement. 
 
 ``po-mu`` also supports 2 player mode on _Project OutFox_ as this was a missing feature from all simulations from the past and was highly requested by the community. 
 

--- a/user-guide/games/techno.md
+++ b/user-guide/games/techno.md
@@ -18,7 +18,7 @@ insert picture of gameplay
 
 This mode was added in the 3.0.2, with the first mode being 8 panel. Like most modes from this period, there were not many theme items or specifics in scoring or timing windows at all. It was rendered almost unplayable due to the rapid code changes of the time, and was fixed in the side fork of 3.9.5 around spring 2004.
 
-In the development of SM 4.0, this mode was broken with the rapid changes brought into the game and was then fixed again by Team SSC in StepMania 5 Preview 4 aroun 2010, restoring doubles and noteskin support. 
+In the development of SM 4.0, this mode was broken with the rapid changes brought into the game and was then fixed again by Team SSC in StepMania 5 Preview 4 around 2010, restoring doubles and noteskin support. 
 
 I have not added the fixes/tweaks done to this mode in the history that were added to the _OutFox_ codebase; though much was done to include the 9 panel support requested by a lot of the community. 
 

--- a/user-guide/setup/install-linux.md
+++ b/user-guide/setup/install-linux.md
@@ -96,7 +96,7 @@ Here is example output from ldd:
 In this example, `libbz2.so.1.0` is missing.
 
 Here's a list of what libraries it looks for and what Debian/Ubuntu/Fedora package it corresponds to. Most systems should have most of these already.
-Library name|Debian/Ubuntu pacakge|Fedora package
+Library name|Debian/Ubuntu package|Fedora package
 --------|-------|--------
 libOpenGL.so.0|libopengl0|libglvnd-opengl
 libGLX.so.0|libglx0|libglvnd-glx
@@ -124,7 +124,7 @@ Assuming the third device is where the audio should be, the whole line for Sound
 
 ---
 ### Needing to force ALSA instead of PulseAudio.
-A wrapper program called `pasuspender` can be used to temporarilly disable pulseaudio and make OutFox use the ALSA drivers.
+A wrapper program called `pasuspender` can be used to temporarily disable pulseaudio and make OutFox use the ALSA drivers.
 
 In the terminal, it would be used like this:
 ```


### PR DESCRIPTION
I was tired that almost every page has a typo.

First commit uses https://github.com/crate-ci/typos and then manually checked. I've ignored release changelogs (I believe those should be frozen) and removed false positives. It's not perfect as it didn't get the latest commit.

- Supersedes/closes https://github.com/TeamRizu/outfox-wiki/pull/33