### PR TITLE
Remove weird curly brackets in courses page

### DIFF
--- a/dev/courses.md
+++ b/dev/courses.md
@@ -8,8 +8,6 @@ editor: markdown
 dateCreated: 2023-05-16T06:16:35.412Z
 ---
 
-{{<toc>}}
-
 ## Location of Courses
 
 The default location for courses are in `Project OutFox/Courses`, with the following structure:


### PR DESCRIPTION
<img width="247" height="166" alt="firefox_Em63PNC5ZS" src="https://github.com/user-attachments/assets/7b81c618-d664-4bbd-b305-a51203941331" />
